### PR TITLE
[fix_gemfile] Rest client conflict fix

### DIFF
--- a/ruby/files/Gemfile
+++ b/ruby/files/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rest_client', '~>1.8.3'
+gem 'rest_client', '~>1.8.0'
 gem 'syncano', '~>4.0.0.pre'
 gem 'mailgun-ruby', '~>1.1.0'
 gem 'pdf-reader', '~>1.4.0'


### PR DESCRIPTION
rest_client no longer has 1.8.3 version, just 2.0.0 or 1.8.0.